### PR TITLE
Fix README line for SCSS styles path

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Directory Structure
 css\              - Stylesheets CSS files for the template.
 images\           - Images used in template.
 scripts\          - JavaScript used in the template.
-styles\           - SCSS source files for stylesheets CSS. Available in Purchased versions only.
+styles\           - SCSS source files for stylesheets CSS. Available in purchased versions only.
 favicon.ico       - Favicon placeholder provided for the template.
 index.html        - Main HTML page to open the template in browser.
 *.html            - Additional HTML pages (if any).


### PR DESCRIPTION
## Summary
- fix wording for SCSS source files line in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840a74e4514832882d99f485fd46bb0